### PR TITLE
support for shallow target keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ defmodule MyApp.PropLoader do
 
   property "foo.bar", {:my_app, MyApp.Foo, :bar}, secret: false, pipeline: [&required/1]
   property "foo.quux", {:my_app, MyApp.Foo, :quux}, secret: false, pipeline: [&required/1, &integer/1]
+
+  property "other_app.thing", {:other_app, :thing}, secret: false, pipeline: [&required/1, &integer/1]
 end
 ```
 

--- a/test/exjprop_loader_test.exs
+++ b/test/exjprop_loader_test.exs
@@ -11,6 +11,8 @@ defmodule Exjprop.LoaderTest do
     property "foo.baz", {:exjprop, Exjprop.Foo, :quux}
     property "foo.quux", {:exjprop, Exjprop.Bar, :foo_quux}, pipeline: [&integer/1]
     property "bar.quux", {:exjprop, Exjprop.Bar, :bar_quux}, pipeline: [&float/1]
+    property "two.key", {:exjprop, :two_key}
+    property "min.key", {:exjprop, :min_key}
   end
 
   setup do
@@ -21,9 +23,10 @@ defmodule Exjprop.LoaderTest do
   test "properties are loaded properly" do
     assert Application.get_env(:exjprop, Exjprop.Foo)[:foo] == nil
     assert Application.get_env(:exjprop, Exjprop.Foo)[:quux] == nil
-    TestModule.load_and_update_env(["foo.bar=three","foo.baz=four"])
+    TestModule.load_and_update_env(["foo.bar=three","foo.baz=four","min.key=tiny"])
     assert Application.get_env(:exjprop, Exjprop.Foo)[:foo] == "three"
     assert Application.get_env(:exjprop, Exjprop.Foo)[:quux] == "four"
+    assert Application.get_env(:exjprop, :min_key) == "tiny"
   end
 
   test "can load props without updating env" do
@@ -51,5 +54,6 @@ defmodule Exjprop.LoaderTest do
     System.put_env(env, "file:///#{@test_props_file}")
     TestModule.load_and_update_env({:system, env})
     assert Application.get_env(:exjprop, Exjprop.Foo)[:foo] == "baz"
+    assert Application.get_env(:exjprop, :two_key) == "slim"
   end
 end

--- a/test/test.properties
+++ b/test/test.properties
@@ -10,7 +10,10 @@ quux.foo=bar
 
    some.prop=more
 
-thing.with=trailing whitespace         
+thing.with=trailing whitespace
 
 
 value.with.equal=foo=bar=baz
+
+
+two.key=slim


### PR DESCRIPTION
Adds support for loading up properties that are not keyword lists.

Also fixes https://github.com/stocks29/exjprop/issues/9